### PR TITLE
Revised QCoreApplication instantiation to address (a) Qt argc & argv warning and (b) core-application exit

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -48,11 +48,11 @@ class Qt5LibraryInfo:
                 sys.stderr = sys.stdout
 
                 import json
-                from %s.QtCore import QLibraryInfo, QCoreApplication
+                from %s.QtCore import (QCoreApplication, QLibraryInfo)
 
                 # QLibraryInfo isn't always valid until a QCoreApplication is
                 # instantiated.
-                app = QCoreApplication([])
+                _ = QCoreApplication(sys.argv).instance().quit()
                 paths = [x for x in dir(QLibraryInfo) if x.endswith('Path')]
                 location = {x: QLibraryInfo.location(getattr(QLibraryInfo, x))
                             for x in paths}


### PR DESCRIPTION
# Summary

PyInstaller 3.4. did not resolve the location to the Qt5 shared libraries (or DLLs) on the Windows 10 environment (March 11, 2019). When compiled, the directory location of each Qt shared library (DLL) is hard-coded inside the shared library code. Also, a configuration file (*.INI), named qt.conf is written (see qt.conf documentation).  The Qt Core shared library provides the QLibraryInfo class, an abstraction used to provide access to the directory locations of the shared libraries. PyInstaller 3.4 resolves the library locations with the QLibraryInfo class (see pyinstaller source code). 

The QLibraryInfo will load the qt.conf file from either: (a) the `:/qt/etc/qt.conf` location via the resource system, (b) the Resource directory in the application bundle, for the mac-OS, or (c) the directory location that contains the application executable, that is `QCoreApplication::applicationDirPath() + QDir::separator() + "qt.conf"`(see qt-conf doc). 

For Windows and X11, Qt takes additional steps in resolving the directory location of shared libraries. Qt states, in regards to shared library locations, that the absolute paths used to point to the location of a shared library are specified in the qt.conf file (see qtconf doc). In addition, all existing paths are relative to the `Prefix` found inside the qt.conf file. Furthermore, for Windows and X11, the `Prefix` is relative to the directory location that holds the application executable via `QCoreApplication::applicationDirPath()` (see qt-conf doc).
 
This suggests that for Windows, the QLibraryInfo first must obtain the directory where the QCoreApplication class is instantiated, in-order to build a directory path that will point to the location of the qt.conf file. Once the qt.conf file is obtained the QLibraryInfo will load the locations that point to the Qt shared libraries (or DLLs). 

The QCoreApplication class initializes a Qt core application - an non-GUI application (console application). The instance method returns a pointer used to control the core application. This pointer enables us to call the quit method. This method tells the application to exit with return code 0 (SUCCESS). 
This standard-out return code works synergistically with the PyInstaller implementation of `exec_command` used indirectly by the Qt5LibraryInfo class. 

Also, the QCoreApplication constructor must be passed argc with an integer value greater than zero and must be passed argv with a string that is at least one character string in length (see qcoreapplication doc).  In summary, the QCoreApplication is instantiated, its pointer obtained and used to immediately cause the core application to exit with a return code. 

As an aside, recall that the object created by QCoreApplication is only used once to call the quit method. While it may be assumed that a variable assignment is not needed, this object should be assigned a dummy variable for a (negligible) improvement in performance that relates to the python garbage collector (see vlad-ardelean and S.Lott).


# References

[qt-conf doc]( https://doc.qt.io/qt-5/qt-conf.html )

[qcoreapplication doc]( https://doc.qt.io/qt-5/qcoreapplication.html#QCoreApplication )

[pyinstaller source code]( https://github.com/pyinstaller/pyinstaller/blob/8c27d2668cb9dea14302a0cffffb7dd997574ee1/PyInstaller/utils/hooks/qt.py#L56 )

[S.Lott](https://stackoverflow.com/questions/843459/how-does-garbage-collection-in-python-work-with-class-methods)

[vlad-ardelean](https://stackoverflow.com/questions/34991812/is-it-fine-to-instantiate-python-class-without-assigning-instance-to-a-variable)

Related Information

[qlibraryinfo doc](https://doc.qt.io/qt-5/qlibraryinfo.html)

[pyside qlibraryinfo doc](https://doc.qt.io/qtforpython/PySide2/QtCore/QLibraryInfo.html?highlight=qlibrary#PySide2.QtCore.PySide2.QtCore.QLibraryInfo.build)

#Appendix 
My System uses python 2.7.13, anaconda2, pyinstaller 3.4 (downloaded on March 11, 2019), pyqt5 5.6, and windows 10.